### PR TITLE
add intermediate flag to include intermediate parent keys in the result

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,17 +18,7 @@ function isObject(value) {
  */
 var isArray = Array.isArray;
 
-/**
- * @description
- * Get an object, and return an array composed of it's properties names(nested too).
- * @param obj {Object}
- * @param stack {Array}
- * @param parent {String}
- * @returns {Array}
- * @example
- * parseKeys({ a:1, b: { c:2, d: { e: 3 } } }) ==> ["a", "b.c", "b.d.e"]
- */
-module.exports = function deepKeys(obj, stack, parent) {
+var deepKeysWithIntermediate = function(obj, stack, parent, intermediate) {
   stack = stack || [];
   var keys = Object.keys(obj);
 
@@ -37,7 +27,7 @@ module.exports = function deepKeys(obj, stack, parent) {
     if(isObject(obj[el]) && !isArray(obj[el])) {
       //concatenate the new parent if exist
       var p = parent ? parent + '.' + el : parent;
-      deepKeys(obj[el], stack, p || el);
+      deepKeysWithIntermediate(obj[el], stack, p || el, intermediate);
     } else {
       //create and save the key
       var key = parent ? parent + '.' + el : el;
@@ -45,4 +35,20 @@ module.exports = function deepKeys(obj, stack, parent) {
     }
   });
   return stack
+};
+
+/**
+ * @description
+ * Get an object, and return an array composed of it's properties names(nested too).
+ * With intermediate equals to true, we include also the intermediate parent keys into the result
+ * @param obj {Object}
+ * @param intermediate {Boolean}
+ * @returns {Array}
+ * @example
+ * deepKeys({ a:1, b: { c:2, d: { e: 3 } } }) ==> ["a", "b.c", "b.d.e"]
+ * @example
+ * deepKeys({ b: { c:2, d: { e: 3 } } }) ==> ["b", "b.c", "b.d", "b.d.e"]
+ */
+module.exports = function deepKeys(obj, intermediate) {
+  return deepKeysWithIntermediate(obj, [], null, intermediate);
 };

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ var deepKeysWithIntermediate = function(obj, stack, parent, intermediate) {
     if(isObject(obj[el]) && !isArray(obj[el])) {
       //concatenate the new parent if exist
       var p = parent ? parent + '.' + el : parent;
+      //Push intermediate parent key if flag is true
+      intermediate && stack.push(parent ? p:el);
       deepKeysWithIntermediate(obj[el], stack, p || el, intermediate);
     } else {
       //create and save the key

--- a/test.js
+++ b/test.js
@@ -47,5 +47,18 @@ describe('deep-keys', function() {
       'isActive'
     ]);
   });
+  
+  it('should return deep keys including intermediate parent keys', function() {
+    var obj1 = {
+      a: 1,
+      b: { c: 1 },
+      c: { d: { e: 1 }, f: 1 },
+      d: { e: { f: { g: 1, h: 2 } } },
+      e: 2,
+      f: { g: [] }
+    };
+    expectEqual(keys(obj1, true), ['a', 'b', 'b.c', 'c', 'c.d', 'c.d.e', 'c.f',
+    'd', 'd.e', 'd.e.f', 'd.e.f.g', 'd.e.f.h', 'e', 'f', 'f.g']);
+  });
 
 });


### PR DESCRIPTION
When using the new intermediate flag to true, the result will include intermediate parent keys.
Exemple
```javascript
var obj = {a : {b : {c : 1}}};
deepKeys(obj, true);
//=> ['a', 'a.b', 'a.b.c']
```

