### PR TITLE
Escape periods (.) in key names

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ deepKeys(obj2);
 var obj3 = {a:{b:{c:1}}};
 deepKeys(obj3);       //=> [ 'a.b.c' ]
 deepKeys(obj3, true); //=> [ 'a', 'a.b', 'a.b.c' ]
+
+// Dots in key names get escaped
+var obj4 = { 'a.': { b: 1} };
+deepKeys(obj4) //=> [ 'a\\..b' ]
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -20,16 +20,18 @@ var isArray = Array.isArray;
 
 function deepKeys(obj, stack, parent, intermediate) {
   Object.keys(obj).forEach(function(el) {
+    // Escape . in the element name
+    var escaped = el.replace(/\./g, '\\\.');
     // If it's a nested object
     if(isObject(obj[el]) && !isArray(obj[el])) {
       // Concatenate the new parent if exist
       var p = parent ? parent + '.' + el : parent;
       // Push intermediate parent key if flag is true
-      if (intermediate) stack.push(parent ? p : el);
-      deepKeys(obj[el], stack, p || el, intermediate);
+      if (intermediate) stack.push(parent ? p : escaped);
+      deepKeys(obj[el], stack, p || escaped, intermediate);
     } else {
       // Create and save the key
-      var key = parent ? parent + '.' + el : el;
+      var key = parent ? parent + '.' + escaped : escaped;
       stack.push(key)
     }
   });
@@ -46,7 +48,9 @@ function deepKeys(obj, stack, parent, intermediate) {
  * @example
  * deepKeys({ a:1, b: { c:2, d: { e: 3 } } }) ==> ["a", "b.c", "b.d.e"]
  * @example
- * deepKeys({ b: { c:2, d: { e: 3 } } }) ==> ["b", "b.c", "b.d", "b.d.e"]
+ * deepKeys({ b: { c:2, d: { e: 3 } } }, true) ==> ["b", "b.c", "b.d", "b.d.e"]
+ * @example
+ * deepKeys({ 'a.': { b: 1 }) ==> ["a\..b"]
  */
 module.exports = function (obj, intermediate) {
   return deepKeys(obj, [], null, intermediate);

--- a/test.js
+++ b/test.js
@@ -47,7 +47,7 @@ describe('deep-keys', function() {
       'isActive'
     ]);
   });
-  
+
   it('should return deep keys including intermediate parent keys', function() {
     var obj1 = {
       a: 1,
@@ -59,6 +59,13 @@ describe('deep-keys', function() {
     };
     expectEqual(keys(obj1, true), ['a', 'b', 'b.c', 'c', 'c.d', 'c.d.e', 'c.f',
     'd', 'd.e', 'd.e.f', 'd.e.f.g', 'd.e.f.h', 'e', 'f', 'f.g']);
+  });
+
+  it('should escape . in key names', function() {
+    var obj1 = { a: { '.b': 1 } };
+    expectEqual(keys(obj1), ['a.\\.b']);
+    var obj2 = { 'a.': { b: 1 } };
+    expectEqual(keys(obj2, true), ['a\\.', 'a\\..b']);
   });
 
 });


### PR DESCRIPTION
`deepKeys({ 'a.': { b: 1 } })` and `deepKeys({ 'a': { '.b': 1} })`
should give distinct results.