### PR TITLE
fix(index): intermediate keys with periods (.) in key names

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function deepKeys(obj, stack, parent, intermediate) {
     // If it's a nested object
     if(isObject(obj[el]) && !isArray(obj[el])) {
       // Concatenate the new parent if exist
-      var p = parent ? parent + '.' + el : parent;
+      var p = parent ? parent + '.' + escaped : parent;
       // Push intermediate parent key if flag is true
       if (intermediate) stack.push(parent ? p : escaped);
       deepKeys(obj[el], stack, p || escaped, intermediate);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   ],
   "devDependencies": {
     "istanbul": "^0.3.2",
-    "mocha": "*"
+    "mocha": "^3.5.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -68,6 +68,10 @@ describe('deep-keys', function() {
     expectEqual(keys(obj1), ['a.\\.b']);
     var obj2 = { 'a.': { b: 1 } };
     expectEqual(keys(obj2, true), ['a\\.', 'a\\..b']);
+    var obj3 = { a: { 'b.d': { c: 1 } } };
+    expectEqual(keys(obj3), ['a.b\\.d.c']);
+    var obj4 = { a: { 'b.d': { c: 1 } } };
+    expectEqual(keys(obj4, true), ['a','a.b\\.d', 'a.b\\.d.c']);
   });
 
 });


### PR DESCRIPTION
``{ a: { 'b.d': { c: 1 } } }`` currently returns ``a.b.d.c``. This fixes so it will correctly return ``a.b\\.d.c``

Also pinned mocha to v3 because [v4 removed node 0.10.0 support](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#400--2017-10-02), which this library currently supports.

If you want, I can make another PR that removes node 0.10.0 support and then target node 4+.